### PR TITLE
Server crashes

### DIFF
--- a/src/SimpleAuth/EventListener.php
+++ b/src/SimpleAuth/EventListener.php
@@ -123,7 +123,7 @@ class EventListener implements Listener{
 		if(!$this->plugin->isPlayerAuthenticated($event->getPlayer())){
 			if(!$event->getPlayer()->hasPermission("simpleauth.move")){
 				$event->setCancelled(true);
-				$event->getPlayer()->inAirTicks = 0;
+				//$event->getPlayer()->inAirTicks = 0;
 			}
 		}
 	}


### PR DESCRIPTION
 Cannot access protected property pocketmine\Player::$inAirTicks in /root/build/10/plugins/SimpleAuth/src/SimpleAuth/EventListener.php on line 126
