### PR TITLE
Add missing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ You can modify the _SimpleAuth/config.yml_ file on the _plugins_ directory once 
 | timeout | integer | 60 | Unauthenticated players will be kicked after this period of time. Set it to 0 to disable. (TODO) |
 | forceSingleSession | boolean | true | New players won't kick an authenticated player if using the same name. |
 | minPasswordLength | integer | 6 | Minimum length of the register password. |
-| authenticateByLastIP | boolean | false | Enables authentication by last IP. |
+| blockAfterFail | integer | 6 | Block clients after several failed attempts |
+| authenticateByLastUniqueId | boolean | false | Enables authentication by last unique id. |
 | dataProvider | string | yaml | Selects the provider to get the data from (yaml, sqlite3, mysql, none) |
 | dataProviderSettings | array | Sets the settings for the chosen dataProvider |
 | disableRegister | boolean | false | Will set all the permissions for simleauth.command.register to false |
@@ -46,7 +47,7 @@ You can modify the _SimpleAuth/config.yml_ file on the _plugins_ directory once 
 | :---: | :---: | :--- |
 | simpleauth.chat | false | Allows using the chat while not being authenticated |
 | simpleauth.move | false | Allows moving while not being authenticated |
-| simpleauth.lastip | notop | Allows authenticating using the lastIP when enabled in the config |
+| simpleauth.lastip | true | Allows authenticating using the lastIP when enabled in the config |
 | simpleauth.command.register | true | Allows registering an account |
 | simpleauth.command.login | true | Allows logging into an account |
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Plugin for PocketMine-MP that prevents people to impersonate an account, requeri
 
 * `/login <password>`
 * `/register <password>`
-* `/unregister <password>` (TODO)
-* For OPs: `/simpleauth <command: help|unregister> [parameters...]` (TODO)
+* `/unregister <password>`
+* For OPs: `/simpleauth <command: unregister> [players ...]`
 
 
 ## Configuration
@@ -50,6 +50,7 @@ You can modify the _SimpleAuth/config.yml_ file on the _plugins_ directory once 
 | simpleauth.lastip | true | Allows authenticating using the lastIP when enabled in the config |
 | simpleauth.command.register | true | Allows registering an account |
 | simpleauth.command.login | true | Allows logging into an account |
+| simpleauth.command.simpleauth | op | Manage accounts |
 
 ## For developers
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,14 @@ commands:
   description: "Registers an account"
   usage: "/register <password>"
   permission: simpleauth.command.register
+ unregister:
+  description: "Unregister an account"
+  usage: "/unregister <password>"
+  permission: simpleauth.command.register
+ simpleauth:
+  description: "Manage accounts"
+  usage: "/simpleauth unregister [player]"
+  permission: simpleauth.command.simpleauth
 
 permissions:
  simpleauth:
@@ -41,3 +49,6 @@ permissions:
      simpleauth.command.login:
       description: "Allows logging into an account"
       default: true
+     simpleauth.command.simpleauth:
+      description: "manage simpleauth accounts"
+      default: op

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: SimpleAuth
 main: SimpleAuth\SimpleAuth
-version: 1.7.0
+version: 1.7.1
 api: 1.12.0
 load: STARTUP
 author: PocketMine Team

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: SimpleAuth
 main: SimpleAuth\SimpleAuth
 version: 1.7.0
-api: 1.8.0
+api: 1.12.0
 load: STARTUP
 author: PocketMine Team
 authors: [shoghicp]
@@ -28,9 +28,9 @@ permissions:
    simpleauth.move:
     description: "Allows moving while not being authenticated"
     default: false
-   simpleauth.lastip:
-    description: "Allows authenticating using the lastIP when enabled in the config"
-    default: notop
+   simpleauth.lastid:
+    description: "Allows authenticating using the last id when enabled in the config"
+    default: true
    simpleauth.command:
     description: "Allows using SimpleAuth commands"
     default: true

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -20,8 +20,11 @@ forceSingleSession: true
 #Sets the minimum amount of characters to be used when registering a new account
 minPasswordLength: 6
 
-#If enabled, accounts that are using the same IP when logging in again will be automatically authenticated
-authenticateByLastIP: false
+#Will block user after this number of failed attempts. Set to 0 to disable
+blockAfterFail: 6
+
+#If enabled, accounts that are using the same unique id (ip + clientId + name) when logging in again will be automatically authenticated
+authenticateByLastUniqueId: false
 
 #If enabled, will set all the permissions for simleauth.command.register to false
 disableRegister: false

--- a/resources/messages.yml
+++ b/resources/messages.yml
@@ -1,9 +1,11 @@
 # SimpleAuth 1.4.0 language file
 
 join:
- message: "This server uses SimpleAuth.\nYou must authenticate to play."
- register: "You are not registered.\nPlease register using: /register <password>"
+ message1: "This server requires account registration."
+ message2: "You must authenticate to play."
+ register: "Please register using: /register <password>"
  login: "Please log in using: /login <password>"
+ popup: "You are not logged in"
 
 register:
  usage: "/register <password>"
@@ -22,3 +24,4 @@ login:
  error:
   password: "Incorrect password!"
   registered: "This account is not registered."
+  block: "Too many tries!"

--- a/resources/messages.yml
+++ b/resources/messages.yml
@@ -25,3 +25,10 @@ login:
   password: "Incorrect password!"
   registered: "This account is not registered."
   block: "Too many tries!"
+  ingame: "This command only works in-game."
+
+simpleauth:
+ unregistered: "%s unregistered"
+ notregistered: "You are no longer registered!"
+ error:
+  unregister: "Unable to unregister %s"

--- a/src/SimpleAuth/EventListener.php
+++ b/src/SimpleAuth/EventListener.php
@@ -48,9 +48,9 @@ class EventListener implements Listener{
 	 * @priority LOWEST
 	 */
 	public function onPlayerJoin(PlayerJoinEvent $event){
-		if($this->plugin->getConfig()->get("authenticateByLastIP") === true and $event->getPlayer()->hasPermission("simpleauth.lastip")){
+		if($this->plugin->getConfig()->get("authenticateByLastId") === true and $event->getPlayer()->hasPermission("simpleauth.lastid")){
 			$config = $this->plugin->getDataProvider()->getPlayer($event->getPlayer());
-			if($config !== null and $config["lastip"] === $event->getPlayer()->getAddress()){
+			if($config !== null and $config["lastip"] === $event->getPlayer()->getUniqueId()){
 				$this->plugin->authenticatePlayer($event->getPlayer());
 				return;
 			}

--- a/src/SimpleAuth/EventListener.php
+++ b/src/SimpleAuth/EventListener.php
@@ -48,7 +48,7 @@ class EventListener implements Listener{
 	 * @priority LOWEST
 	 */
 	public function onPlayerJoin(PlayerJoinEvent $event){
-		if($this->plugin->getConfig()->get("authenticateByLastId") === true and $event->getPlayer()->hasPermission("simpleauth.lastid")){
+		if($this->plugin->getConfig()->get("authenticateByLastUniqueId") === true and $event->getPlayer()->hasPermission("simpleauth.lastid")){
 			$config = $this->plugin->getDataProvider()->getPlayer($event->getPlayer());
 			if($config !== null and $config["lastip"] === $event->getPlayer()->getUniqueId()){
 				$this->plugin->authenticatePlayer($event->getPlayer());

--- a/src/SimpleAuth/SimpleAuth.php
+++ b/src/SimpleAuth/SimpleAuth.php
@@ -140,7 +140,7 @@ class SimpleAuth extends PluginBase{
 	}
 
 	public function tryAuthenticatePlayer(Player $player){
-		if($this->isPlayerAuthenticated($player)){
+		if($this->blockPlayers <= 0 and $this->isPlayerAuthenticated($player)){
 			return;
 		}
 

--- a/src/SimpleAuth/provider/DataProvider.php
+++ b/src/SimpleAuth/provider/DataProvider.php
@@ -58,10 +58,10 @@ interface DataProvider{
 
 	/**
 	 * @param IPlayer $player
-	 * @param string  $lastIP
+	 * @param string  $lastId
 	 * @param int     $loginDate
 	 */
-	public function updatePlayer(IPlayer $player, $lastIP = null, $loginDate = null);
+	public function updatePlayer(IPlayer $player, $lastId = null, $loginDate = null);
 
 	public function close();
 }

--- a/src/SimpleAuth/task/ShowMessageTask.php
+++ b/src/SimpleAuth/task/ShowMessageTask.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * SimpleAuth plugin for PocketMine-MP
+ * Copyright (C) 2014 PocketMine Team <https://github.com/PocketMine/SimpleAuth>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+*/
+
+namespace SimpleAuth\task;
+
+use pocketmine\Player;
+use pocketmine\scheduler\PluginTask;
+use pocketmine\utils\TextFormat;
+use SimpleAuth\SimpleAuth;
+
+class ShowMessageTask extends PluginTask{
+
+	/** @var Player[] */
+	private $playerList = [];
+
+	public function __construct(SimpleAuth $plugin){
+		parent::__construct($plugin);
+	}
+
+	/**
+	 * @return SimpleAuth
+	 */
+	public function getPlugin(){
+		return $this->owner;
+	}
+
+	public function addPlayer(Player $player){
+		$this->playerList[$player->getUniqueId()] = $player;
+	}
+
+	public function removePlayer(Player $player){
+		unset($this->playerList[$player->getUniqueId()]);
+	}
+
+	public function onRun($currentTick){
+		$plugin = $this->getPlugin();
+		if($plugin->isDisabled()){
+			return;
+		}
+
+		foreach($this->playerList as $player){
+			$player->sendPopup(TextFormat::ITALIC . TextFormat::GRAY . $this->getPlugin()->getMessage("join.popup"));
+		}
+	}
+
+}


### PR DESCRIPTION
Implementing the **TODO** command items listed in the `README.md`:

* `/unregister`
* `/simpleauth unregister`

I need this to allow password changes and to reset accounts of users who forgot their passwords.
