### PR TITLE
Fixed to prevent an error

### DIFF
--- a/src/SimpleAuth/task/ShowMessageTask.php
+++ b/src/SimpleAuth/task/ShowMessageTask.php
@@ -39,11 +39,11 @@ class ShowMessageTask extends PluginTask{
 	}
 
 	public function addPlayer(Player $player){
-		$this->playerList[$player->getUniqueId()] = $player;
+		$this->playerList[spl_object_hash($player->getUniqueId())] = $player;
 	}
 
 	public function removePlayer(Player $player){
-		unset($this->playerList[$player->getUniqueId()]);
+		$this->playerList[spl_object_hash($player->getUniqueId())] = null;
 	}
 
 	public function onRun($currentTick){
@@ -53,8 +53,10 @@ class ShowMessageTask extends PluginTask{
 		}
 
 		foreach($this->playerList as $player){
+			if($player==null){
+				continue;
+			}
 			$player->sendPopup(TextFormat::ITALIC . TextFormat::GRAY . $this->getPlugin()->getMessage("join.popup"));
 		}
 	}
-
 }


### PR DESCRIPTION
This can prevent these errors:

2015-09-10 [22:21:15] [Server thread/CRITICAL]: "Could not pass event 'pocketmine\event\player\PlayerJoinEvent' to 'SimpleAuth v1.7.1': Illegal offset type on SimpleAuth\EventListener
2015-09-10 [22:21:15] [Server thread/WARNING]: RuntimeException: "Illegal offset type" (E_WARNING) in "/plugins/SimpleAuth_v1.7.1.phar/src/SimpleAuth/task/ShowMessageTask" at line 42

2015-09-10 [22:21:29] [Server thread/CRITICAL]: Unhandled exception executing command 'register [HIDDEN]' in register: Illegal offset type in unset
2015-09-10 [22:21:29] [Server thread/WARNING]: RuntimeException: "Illegal offset type in unset" (E_WARNING) in "/plugins/SimpleAuth_v1.7.1.phar/src/SimpleAuth/task/ShowMessageTask" at line 46
2015-09-10 [22:21:39] [Server thread/CRITICAL]: "Could not pass event 'pocketmine\event\player\PlayerQuitEvent' to 'SimpleAuth v1.7.1': Illegal offset type in unset on SimpleAuth\EventListener
2015-09-10 [22:21:39] [Server thread/WARNING]: RuntimeException: "Illegal offset type in unset" (E_WARNING) in "/plugins/SimpleAuth_v1.7.1.phar/src/SimpleAuth/task/ShowMessageTask" at line 46

This patch is very easy, but it wastes memory a little.